### PR TITLE
Updated Get-ICBoxes to work with -TargetGroupId

### DIFF
--- a/HUNT Powershell Module/targetgroupmgmt.ps1
+++ b/HUNT Powershell Module/targetgroupmgmt.ps1
@@ -183,7 +183,7 @@ function Get-ICBoxes ([Switch]$Last90, [Switch]$Last7, [Switch]$Last30, [Switch]
   }
 
   if ($targetGroupId) {
-    $filter.where['and'] += @{ targetId = $targetGroupId }
+    $filter.where['and'] += @{ targetId = "$($targetGroupId)" }
   }
   elseif ($Global) {
     $filter.where['and'] += @{ targetId = $null }


### PR DESCRIPTION
Made $targetGroupId double quoted to be parameterized properly (due to dashes in string).